### PR TITLE
Improve error message when calling static methods like instance methods

### DIFF
--- a/samples/classes/static_method_called_on_object_instance.error
+++ b/samples/classes/static_method_called_on_object_instance.error
@@ -1,0 +1,1 @@
+Cannot call static method on an instance of an object

--- a/samples/classes/static_method_called_on_object_instance.jakt
+++ b/samples/classes/static_method_called_on_object_instance.jakt
@@ -1,0 +1,10 @@
+class Foo {
+    function bar() {
+        println("I am a static method")
+    }
+}
+
+function main() {
+    let foo = Foo()
+    foo.bar()
+}

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -3261,6 +3261,14 @@ pub fn typecheck_call(
                     }
                 }
 
+                // Make sure that our call doesn't have a 'this' pointer to a static callee
+                if this_expr.is_some() && callee.is_static() {
+                    error = error.or(Some(JaktError::TypecheckError(
+                        "Cannot call static method on an instance of an object".to_string(),
+                        *span,
+                    )));
+                }
+
                 // This will be 0 for functions or 1 for instance methods, because of the
                 // 'this' ptr
                 let arg_offset = if this_expr.is_some() { 1 } else { 0 };


### PR DESCRIPTION
Previously, this would error with `wrong number of arguments`. While this is correct, calling a static method through an object instance doesn't make sense, so let's be more specific as to what is actually wrong with the call.

```
class Foo {
    function bar() {
        println("I am missing a this parameter")
    }
}

function main() {
    let foo = Foo()
    foo.bar() // TypecheckError "wrong number of arguments"
}
```